### PR TITLE
Rename job to "Non-Interactive Classifier"

### DIFF
--- a/wrappers/classification.py
+++ b/wrappers/classification.py
@@ -34,7 +34,7 @@ from rodan.jobs.base import RodanTask
 
 
 class ClassificationTask(RodanTask):
-    name = 'Classifier'
+    name = 'Non-Interactive Classifier'
     author = "Ling-Xiao Yang"
     description = "Performs classification on a binarized staff-less image and outputs an xml file."
     enabled = True


### PR DESCRIPTION
Based on discussion which concluded the name "Classifier" is ambiguous considering there are other classifiers. "Non-Interactive Classifier" also aligns with Gamera documentation which uses the terms non-interactive and interactive.